### PR TITLE
コンテナを起動するときに自動で依存するパッケージをインストールするようにする

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "3000:3000"
     volumes:
       - ./frontend:/src # ローカルをコンテナ内にマウント
-    command: sh -c "cd react-project && npm start" #コンテナを立ち上げたときに自動的にbuildする
+    command: sh -c "cd react-project && npm install && npm start" #コンテナを立ち上げたときに自動的にbuildする
     environment:
       - WATCHPACK_POLLING=true
 


### PR DESCRIPTION
### 変更の詳細
依存しているパッケージを手動でnpm installしていたが、コンテナを起動するごとに必要なパッケージが足りていなければ、インストールするようにした
### 変更理由
- 開発しているブランチは現在mainブランチの前のバージョンから派生しているので、必要なパッケージが足りないため、ブランチを切り替えてコンテナを起動したとき毎回エラーが出て、npm installを実行しているため
- npm installはインストールするパッケージがない場合、実行時間が短かったため
### 動作確認
以前と同じように機能するか確認する