### PR TITLE
404画面追加

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -8,6 +8,13 @@ server {
         index index.html index.html;
         try_files $uri /index.html;
     }
+
+    error_page 404 /404.html;
+    location = /404.html {
+        root /var/www/react-project/build;
+        internal;
+    }
+
     error_page 500 502 503 504 /50x.html;
     location = /50x.html {
         root /usr/share/nginx/html;

--- a/frontend/react-project/public/404.html
+++ b/frontend/react-project/public/404.html
@@ -1,0 +1,13 @@
+<!-- public/404.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>404 - Page Not Found</title>
+</head>
+<body>
+    <h1>404 - Page Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+</body>
+</html>

--- a/frontend/react-project/src/App.tsx
+++ b/frontend/react-project/src/App.tsx
@@ -8,6 +8,7 @@ import Blog from './pages/blog';
 import Media from './pages/media';
 import Contact from './pages/contact';
 import Access from './pages/access';
+import NotFound from './pages/404';
 
 const App: React.FC = () => {
   return (
@@ -37,6 +38,7 @@ const App: React.FC = () => {
             <Route path="/media" element={<Media />} />
             <Route path="/contact" element={<Contact />} />
             <Route path="/access" element={<Access />} />
+            <Route path="*" element={<NotFound />} />
           </Routes>
         </main>
         <footer className="App-footer">

--- a/frontend/react-project/src/pages/404.tsx
+++ b/frontend/react-project/src/pages/404.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const NotFound: React.FC = () => (
+  <div>
+    <h1>404 - Page Not Found</h1>
+    <p>The page you are looking for does not exist.</p>
+  </div>
+);
+
+export default NotFound;


### PR DESCRIPTION
### 変更の詳細
存在しないパスにアクセスしようとしたら404ページを表示するようにするようにした

docker/nginx/default.conf
nginxの設定

frontend/react-project/public/404.html
npm buildで作成されたファイル。サイトで表示されるページ

frontend/react-project/src/App.tsx
404ページのルーティング追加

frontend/react-project/src/pages/404.tsx
サイトで表示されるページ元となるファイル

### 動作確認
存在しないパスにアクセスしたら４０４ページに映るか
（localhost:8080〜）